### PR TITLE
Reuse of access token and getting one project while saving instance

### DIFF
--- a/Scripts/CheckmarxOneAppListIntegration_sys_script_include_f60f0ee047131110328ca368436d43ba.xml
+++ b/Scripts/CheckmarxOneAppListIntegration_sys_script_include_f60f0ee047131110328ca368436d43ba.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-15 06:21:19">
+<unload unload_date="2023-06-23 11:09:33">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -21,7 +21,6 @@ CheckmarxOneAppListIntegration.prototype = Object.extendsObject(sn_vul.Applicati
         if (params.run) {
             //  filteredcount,  offset
             response = this.getAppList(Object.keys(params.run)[0], params.run[Object.keys(params.run)[0]]);
-            this.validateXML(response, 'error');
         }
         params = this._serializeParameters(this._nextParameters(params));
         this.setNextRunParameters(params);
@@ -60,14 +59,14 @@ CheckmarxOneAppListIntegration.prototype = Object.extendsObject(sn_vul.Applicati
                 if (groups == 0) {
                     appListAll += '<project id="' + response.projects[item].id +
                         '" name="' + response.projects[item].id +
-                        ' createdAt:' + response.projects[item].createdAt +
+                        '" createdAt:"' + response.projects[item].createdAt +
                         '" groups="' + groupval + '">' +
                         '<description><' + '![CDATA[' + response.projects[item].name + ']]' + '></description></project>';
 
                 } else {
                     appListAll += '<project id="' + response.projects[item].id +
                         '" name="' + response.projects[item].id +
-                        ' createdAt:' + response.projects[item].createdAt +
+                        '" createdAt:"' + response.projects[item].createdAt +
                         '" groups="' + response.projects[item].groups.toString() + '">' +
                         '<description><' + '![CDATA[' + response.projects[item].name + ']]' + '></description></project>';
                 }
@@ -183,13 +182,13 @@ CheckmarxOneAppListIntegration.prototype = Object.extendsObject(sn_vul.Applicati
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-18 05:11:38</sys_created_on>
 <sys_id>f60f0ee047131110328ca368436d43ba</sys_id>
-<sys_mod_count>131</sys_mod_count>
+<sys_mod_count>138</sys_mod_count>
 <sys_name>CheckmarxOneAppListIntegration</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_f60f0ee047131110328ca368436d43ba</sys_update_name>
-<sys_updated_by>apoorva.singh@checkmarx.com</sys_updated_by>
-<sys_updated_on>2023-06-06 17:18:33</sys_updated_on>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2023-06-23 11:00:11</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneAppListProcessor_sys_script_include_716c87ad471f1110328ca368436d438a.xml
+++ b/Scripts/CheckmarxOneAppListProcessor_sys_script_include_716c87ad471f1110328ca368436d438a.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-15 06:21:38">
+<unload unload_date="2023-06-23 11:07:36">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -15,19 +15,28 @@ CheckmarxOneAppListProcessor.prototype = Object.extendsObject(sn_vul.Application
      *    passed individually to the VR AppVul API
      */
     MSG: 'CheckmarxOne AppListProcessor:',
-    process: function (attachment) {
+    UTIL: new x_chec3_chexone.CheckmarxOneUtil(),
+
+    process: function(attachment) {
         if (!attachment) {
             gs.warn(gs.getMessage('CheckmarxOneAppListProcessor: Called with no attachment'));
             return;
         }
         try {
+            this.UTIL.validateXML(new GlideSysAttachment().getContent(attachment), 'error');
             //Parsing the Project List attachment
             var appDoc = new XMLDocument2();
             appDoc.parseXML(new GlideSysAttachment().getContent(attachment));
             var listNode = appDoc.getNode("/appInfoList/xml/projects");
             var iter = listNode.getChildNodeIterator();
-            
-            while (iter.hasNext()) {
+
+        } catch (ex) {
+            gs.error(this.MSG + "Error occurred while validating or parsing the XML: " + ex);
+            throw ex;
+        }
+        var errorProcess = '';
+        while (iter.hasNext()) {
+            try {
                 var appNode = iter.next();
                 var attributes = appNode.getAttributes();
                 //map attributes from Checkmarx into the servicenow expected format'
@@ -47,14 +56,16 @@ CheckmarxOneAppListProcessor.prototype = Object.extendsObject(sn_vul.Application
                     else if (result.unchanged)
                         this.import_counts.unchanged++;
                 }
-               
+            } catch (ex) {
+                errorMessage = gs.getMessage("Error in retriving data for app list integration!");
+                gs.error(this.MSG + "errorMessage " + ex);
+                errorProcess += " | " + ex.getMessage();
+                //   throw ex;
             }
-        } catch (ex) {
-            errorMessage = gs.getMessage("Error in retriving data for app list integration!");
-            gs.error(this.MSG + "errorMessage " + ex);
-            throw ex;
         }
 
+        if (!gs.nil(errorProcess))
+            gs.error(this.MSG + "All errors that occurred while processing project lists: " + errorProcess);
         this.completeProcess(this.integrationProcessGr, this.import_counts);
     },
 
@@ -65,13 +76,13 @@ CheckmarxOneAppListProcessor.prototype = Object.extendsObject(sn_vul.Application
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-21 12:03:00</sys_created_on>
 <sys_id>716c87ad471f1110328ca368436d438a</sys_id>
-<sys_mod_count>46</sys_mod_count>
+<sys_mod_count>54</sys_mod_count>
 <sys_name>CheckmarxOneAppListProcessor</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_716c87ad471f1110328ca368436d438a</sys_update_name>
-<sys_updated_by>apoorva.singh@checkmarx.com</sys_updated_by>
-<sys_updated_on>2023-06-06 06:23:26</sys_updated_on>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2023-06-23 11:02:41</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneAppVulItemProcessor_sys_script_include_ba2b3da69769e510026f72021153af1b.xml
+++ b/Scripts/CheckmarxOneAppVulItemProcessor_sys_script_include_ba2b3da69769e510026f72021153af1b.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-19 13:21:17">
+<unload unload_date="2023-06-23 11:14:28">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -19,15 +19,23 @@ CheckmarxOneAppVulItemProcessor.prototype = Object.extendsObject(sn_vul.Applicat
 
     process: function(attachment) {
 
-        if (attachment) {
-            try {
-                var doc = new XMLDocument2();
-                doc.parseXML(new GlideSysAttachment().getContent(attachment));
-                var listNode = doc.getNode('/detailedreport/xml/results');
-                var reportData = {};
+         if (attachment) {
+             try {
+                 this.UTIL.validateXML(new GlideSysAttachment().getContent(attachment), 'error');   
+                 var doc = new XMLDocument2();
+                 doc.parseXML(new GlideSysAttachment().getContent(attachment));
+                 var listNode = doc.getNode('/detailedreport/xml/results');
+             } catch (ex) {
+                 gs.error(this.MSG + "Error occurred while validating or parsing the XML: " + ex);
+                 throw ex;
+             }  
+		var reportData = {};
+		var errorProcess = '';
+
                 if (listNode) {
                     var iter = listNode.getChildNodeIterator();
                     while (iter.hasNext()) {
+						try {
                         var node = iter.next();
                         reportData['source_app_id'] = node.getAttribute('app_id');
                         reportData['app_name'] = node.getAttribute('app_id');
@@ -126,20 +134,20 @@ CheckmarxOneAppVulItemProcessor.prototype = Object.extendsObject(sn_vul.Applicat
                         }
 						
                         this._upsertQuery(queryData);
-						this._upsertAVIT(resultObj);
-                        
-                    }
+                        this._upsertAVIT(resultObj);
+						} catch (ex) {
+							errorMessage = gs.getMessage("Error in retriving data for app list integration!");
+							gs.error(this.MSG + "errorMessage " + ex);
+							errorProcess += " | "+ ex.getMessage();
+							// throw ex;
+						} 
                 }
-            } catch (ex) {
-                errorMessage = gs.getMessage("Error in retriving data for app list integration!");
-                gs.error(this.MSG + "errorMessage " + ex);
-                throw ex;
-            }
-
-        }
-        this.completeProcess(this.integrationProcessGr, this.import_counts);
-
-
+            } 	
+		if(!gs.nil(errorProcess)) 
+			gs.error(this.MSG + "All errors that occurred while processing Vulnerability lists: " + errorProcess); 
+           this.completeProcess(this.integrationProcessGr, this.import_counts);
+        } else
+            gs.warn(this.MSG + ':process called with no attachment');
     },
 
     //updating data to app vul entry table
@@ -205,13 +213,13 @@ CheckmarxOneAppVulItemProcessor.prototype = Object.extendsObject(sn_vul.Applicat
 <sys_created_by>apoorva.singh@checkmarx.com</sys_created_by>
 <sys_created_on>2023-03-16 05:04:10</sys_created_on>
 <sys_id>ba2b3da69769e510026f72021153af1b</sys_id>
-<sys_mod_count>22</sys_mod_count>
+<sys_mod_count>23</sys_mod_count>
 <sys_name>CheckmarxOneAppVulItemProcessor</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_ba2b3da69769e510026f72021153af1b</sys_update_name>
 <sys_updated_by>admin</sys_updated_by>
-<sys_updated_on>2023-06-19 08:30:58</sys_updated_on>
+<sys_updated_on>2023-06-22 08:11:09</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneConfigUtilBase_sys_script_include_508f0d54471f1110328ca368436d43f8.xml
+++ b/Scripts/CheckmarxOneConfigUtilBase_sys_script_include_508f0d54471f1110328ca368436d43f8.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-16 10:54:08">
+<unload unload_date="2023-06-22 07:24:41">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>package_private</access>
 <active>true</active>
@@ -22,7 +22,7 @@ CheckmarxOneConfigUtilBase.prototype = {
                     "result": "false",
                     "errorMessage": gs.getMessage("CheckmarxOne configuration not found.")
                 };
-            var response = new x_chec3_chexone.CheckmarxOneUtil().getProjectList(config.getValue("integration_instance"));
+            var response = new x_chec3_chexone.CheckmarxOneUtil().getProject(config.getValue("integration_instance"));
 
         } catch (ex) {
             result = false;
@@ -80,13 +80,13 @@ CheckmarxOneConfigUtilBase.prototype = {
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-17 05:45:19</sys_created_on>
 <sys_id>508f0d54471f1110328ca368436d43f8</sys_id>
-<sys_mod_count>33</sys_mod_count>
+<sys_mod_count>34</sys_mod_count>
 <sys_name>CheckmarxOneConfigUtilBase</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_508f0d54471f1110328ca368436d43f8</sys_update_name>
 <sys_updated_by>admin</sys_updated_by>
-<sys_updated_on>2023-06-16 07:57:43</sys_updated_on>
+<sys_updated_on>2023-06-22 07:17:09</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
+++ b/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-16 10:53:19">
+<unload unload_date="2023-06-23 11:11:24">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -21,7 +21,6 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
         if (params.run) {
             //  appId,  offset
             response = this.getSummaryReport(Object.keys(params.run)[0], params.run[Object.keys(params.run)[0]]);
-            this.validateXML(response, 'error');
         }
         params = this._serializeParameters(this._nextParameters(params));
         this.setNextRunParameters(params);
@@ -231,13 +230,13 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-18 05:18:19</sys_created_on>
 <sys_id>d7f2d2e447131110328ca368436d4321</sys_id>
-<sys_mod_count>147</sys_mod_count>
+<sys_mod_count>149</sys_mod_count>
 <sys_name>CheckmarxOneScanSummaryIntegration</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_d7f2d2e447131110328ca368436d4321</sys_update_name>
 <sys_updated_by>admin</sys_updated_by>
-<sys_updated_on>2023-06-16 10:35:52</sys_updated_on>
+<sys_updated_on>2023-06-23 11:11:14</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneScanSummaryProcessor_sys_script_include_ec0e828f47f42110328ca368436d433b.xml
+++ b/Scripts/CheckmarxOneScanSummaryProcessor_sys_script_include_ec0e828f47f42110328ca368436d433b.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-02 10:59:47">
+<unload unload_date="2023-06-23 11:12:33">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -11,17 +11,32 @@
 <script><![CDATA[var CheckmarxOneScanSummaryProcessor = Class.create();
 CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.ApplicationVulnerabilityImportProcessorBase, {
     MSG: 'CheckmarxOne Scan Summary Processor: ',
+	UTIL: new x_chec3_chexone.CheckmarxOneUtil(),
+
     process: function(attachment) {
         if (attachment) {
             try {
+                this.UTIL.validateXML(new GlideSysAttachment().getContent(attachment), 'error');   
                 var doc = new XMLDocument2();
                 doc.parseXML(new GlideSysAttachment().getContent(attachment));
                 var Node = doc.getNode('/scanData');
-                if (Node.toString().includes("sastScanData")) {
+            } catch (ex) {
+                gs.error(this.MSG + "Error occurred while validating or parsing the XML: " + ex);
+                throw ex;
+            }
+            var errorProcess = '';
+
+            if (Node.toString().includes("sastScanData")) {
+                try {
                     var sastnodes = doc.getNode('/scanData/sastScanData/scans');
                     var iteration = sastnodes.getChildNodeIterator();
-                    var sastdata = {};
-                    while (iteration.hasNext()) {
+                } catch (ex) {
+                    gs.error(this.MSG + "Error occurred while parsing the XML: " + ex);
+                    throw ex;
+                }
+                var sastdata = {};
+                while (iteration.hasNext()) {
+                    try {
                         var SastappNode = iteration.next();
                         var Sastattributes = SastappNode.getAttributes();
                         //map attributes from CheckmarxOne into the servicenow scan summary table
@@ -31,13 +46,25 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
                         sastdata['last_scan_date'] = new GlideDateTime(Sastattributes.last_scan_date);
                         sastdata['scan_summary_name'] = Sastattributes.app_name + ' ' + sastdata['last_scan_date'];
                         this._upsert(sastdata);
+                    } catch (ex) {
+                        errorMessage = gs.getMessage("Error in retriving data for scan list integration!");
+                        gs.error(this.MSG + "errorMessage " + ex);
+                        errorProcess += " | " + ex.getMessage();
+                        //throw ex;
                     }
                 }
-                if (Node.toString().includes("scaScanData")) {
+            }
+            if (Node.toString().includes("scaScanData")) {
+                try {
                     var scanodes = doc.getNode('/scanData/scaScanData/scans');
-                    var data = {};
                     var iter = scanodes.getChildNodeIterator();
-                    while (iter.hasNext()) {
+                } catch (ex) {
+                    gs.error(this.MSG + "Error occurred while validating or parsing the XML: " + ex);
+                    throw ex;
+                }
+                var data = {};
+                while (iter.hasNext()) {
+                    try {
                         var appNode = iter.next();
                         var attributes = appNode.getAttributes();
                         //map attributes from Checkmarx into the servicenow scan summary table
@@ -47,14 +74,17 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
                         data['last_scan_date'] = new GlideDateTime(attributes.last_scan_date);
                         data['scan_summary_name'] = attributes.app_name + ' ' + data['last_scan_date'];
                         this._upsert(data);
+                    } catch (ex) {
+                        errorMessage = gs.getMessage("Error in retriving data for scan list integration!");
+                        gs.error(this.MSG + "errorMessage " + ex);
+                        errorProcess += " | " + ex.getMessage();
+                        //throw ex;
                     }
                 }
-                this.completeProcess(this.integrationProcessGr, this.import_counts);
-            } catch (ex) {
-                errorMessage = gs.getMessage("Error in retriving data for scan list integration!");
-                gs.error(this.MSG + "errorMessage " + ex);
-                throw ex;
             }
+            if (!gs.nil(errorProcess))
+                gs.error(this.MSG + "All errors that occurred while processing scan summary: " + errorProcess);
+            this.completeProcess(this.integrationProcessGr, this.import_counts);
 
         } else
             gs.warn(this.MSG + ':process called with no attachment');
@@ -105,13 +135,13 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2023-02-08 12:56:43</sys_created_on>
 <sys_id>ec0e828f47f42110328ca368436d433b</sys_id>
-<sys_mod_count>7</sys_mod_count>
+<sys_mod_count>8</sys_mod_count>
 <sys_name>CheckmarxOneScanSummaryProcessor</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_ec0e828f47f42110328ca368436d433b</sys_update_name>
-<sys_updated_by>apoorva.singh@checkmarx.com</sys_updated_by>
-<sys_updated_on>2023-05-23 14:56:22</sys_updated_on>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2023-06-22 08:04:04</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneUtilBase_sys_script_include_1980bcb147935110328ca368436d435a.xml
+++ b/Scripts/CheckmarxOneUtilBase_sys_script_include_1980bcb147935110328ca368436d435a.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-22 07:22:17">
+<unload unload_date="2023-06-23 11:17:09">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -359,8 +359,8 @@ CheckmarxOneUtilBase.prototype = {
     _getToken: function(baseUrl, config, method, request, username, password, ast_client_id, tenant, currentToken) {
         try {
             var accessToken = currentToken;
-            if (accessToken == null || accessToken == "" || this.isTokenExpired(this.getExpTimeFromAccessToken(accessToken)) || !this._checkClientId(username, accessToken)) {
-                var fullUrl = baseUrl + '/auth/realms/' + tenant + '/protocol/openid-connect/token';
+			if (accessToken == null || accessToken == ""  || this._isTokenExpired(this._getExpTimeFromAccessToken(accessToken)) || !this._checkClientId(username, accessToken)) { 
+				var fullUrl = baseUrl + '/auth/realms/' + tenant + '/protocol/openid-connect/token';
                 var query = "client_id=" + username + "&grant_type=" + "client_credentials" + "&client_secret=" + password;
                 request.setEndpoint(fullUrl);
                 request.setHttpMethod(method);
@@ -581,7 +581,25 @@ CheckmarxOneUtilBase.prototype = {
     importSastFlaw: function(configId) {
         return this._getConfig(configId).import_sast;
     },
-
+	
+	//validate XML
+	validateXML: function(body, errorNodeName) {
+        if (!body) return;
+        var doc = new XMLDocument2();
+        doc.parseXML(body);
+        var err = null;
+        try {
+            var root = doc.getFirstNode('/' + doc.getDocumentElement().getNodeName());
+            if (errorNodeName && root.getNodeName() == errorNodeName)
+                err = root.getTextContent();
+            else
+                doc.getNextNode(root);
+        } catch (e) {
+            throw 'XML document syntax invalid';
+        }
+        if (err)
+            throw this.MSG+ 'Error: ' + err;
+    },
 
     type: 'CheckmarxOneUtilBase'
 };]]></script>
@@ -589,13 +607,13 @@ CheckmarxOneUtilBase.prototype = {
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-21 19:26:28</sys_created_on>
 <sys_id>1980bcb147935110328ca368436d435a</sys_id>
-<sys_mod_count>147</sys_mod_count>
+<sys_mod_count>150</sys_mod_count>
 <sys_name>CheckmarxOneUtilBase</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_1980bcb147935110328ca368436d435a</sys_update_name>
 <sys_updated_by>admin</sys_updated_by>
-<sys_updated_on>2023-06-22 07:21:21</sys_updated_on>
+<sys_updated_on>2023-06-23 11:17:01</sys_updated_on>
 </sys_script_include>
 </unload>

--- a/Scripts/CheckmarxOneUtilBase_sys_script_include_1980bcb147935110328ca368436d435a.xml
+++ b/Scripts/CheckmarxOneUtilBase_sys_script_include_1980bcb147935110328ca368436d435a.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<unload unload_date="2023-06-19 13:21:07">
+<unload unload_date="2023-06-22 07:22:17">
 <sys_script_include action="INSERT_OR_UPDATE">
 <access>public</access>
 <active>true</active>
@@ -29,6 +29,22 @@ CheckmarxOneUtilBase.prototype = {
         }
         return this._makeRestCall(apiurl, configId, token, 'projects', "get");
     },
+	//get one project from project list
+	getProject: function(configId) {
+		try {
+            var request = new sn_ws.RESTMessageV2();
+            var config = this._getConfig(configId);
+            var accesscontrolbaseUrl = config.checkmarxone_server_url;
+            var apibaseurl = config.checkmarxone_api_base_url;
+            var method = "post";
+            var token = this.getAccessToken(accesscontrolbaseUrl, config, method, request);
+            var query = '/api/projects/?offset=0&limit=1';
+        } catch (err) {
+            gs.error(this.MSG + " getProjectInfo: Error while getting project.");
+            throw err;
+        }
+        return this._makeRestApiCall(apibaseurl, configId, token, query, "get");
+	},
     //get new project list
     getNewProjectList: function(configId) {
         try {
@@ -327,6 +343,7 @@ CheckmarxOneUtilBase.prototype = {
                 "include_first_detection_date": gr.getValue("include_first_detection_date") === "1",
                 "import_sca": gr.getValue("import_sca") === "1",
                 "import_sast": gr.getValue("import_sast") === "1",
+				"access_token": gr.getValue("access_token"),
             };
         } catch (err) {
             gs.error(this.MSG + " :_getConfig :Error in getting the configuration.");
@@ -342,7 +359,7 @@ CheckmarxOneUtilBase.prototype = {
     _getToken: function(baseUrl, config, method, request, username, password, ast_client_id, tenant, currentToken) {
         try {
             var accessToken = currentToken;
-            if (accessToken == null || accessToken == "" || this.isTokenExpired(this.getExpTimeFromAccessToken(accessToken))) {
+            if (accessToken == null || accessToken == "" || this.isTokenExpired(this.getExpTimeFromAccessToken(accessToken)) || !this._checkClientId(username, accessToken)) {
                 var fullUrl = baseUrl + '/auth/realms/' + tenant + '/protocol/openid-connect/token';
                 var query = "client_id=" + username + "&grant_type=" + "client_credentials" + "&client_secret=" + password;
                 request.setEndpoint(fullUrl);
@@ -366,6 +383,44 @@ CheckmarxOneUtilBase.prototype = {
         }
         return accessToken;
     },
+	
+	//Compare current clientId with accessToken's clientId
+    _checkClientId: function(clientId, accessToken) {
+        var tokenPayload = accessToken.split(".")[1];
+		var tokenPayloadJson = JSON.parse(gs.base64Decode(tokenPayload));
+		var clientIdToken = tokenPayloadJson.azp;
+		if(clientId == clientIdToken) 
+			return true;
+		return false;
+    },
+	// Get expiry token from JWT access token
+	_getExpTimeFromAccessToken: function(accessToken) {
+		try{
+		var splittedStr = accessToken.split(".");
+		var decodedToken = JSON.parse(gs.base64Decode(splittedStr[1]));
+		var expTime = decodedToken.exp;
+		} catch(err){
+			gs.error(this.MSG +" :getExpTimeFromAccessToken :Error in getExpTimeFromAccessToken.");
+			throw err;
+		}
+		return expTime;
+	},
+	// This method checks  if access token is expired or not.
+	_isTokenExpired: function(tokenExpTime) {
+		try {
+			var dateTime = new GlideDateTime();
+			var currentTime = dateTime.getNumericValue() / 1000;
+			currentTime = parseInt(currentTime);
+            if (currentTime > tokenExpTime) 
+                return true;
+			else 
+                return false;
+		} catch (err) {
+			gs.error(this.MSG + " :isTokenExpired :Error in isTokenExpired().");
+			throw err;
+		}
+	},
+	
     _makeRestCall: function(apiurl, configId, token, apiPath, method, params) {
         var request;
         try {
@@ -534,13 +589,13 @@ CheckmarxOneUtilBase.prototype = {
 <sys_created_by>admin</sys_created_by>
 <sys_created_on>2022-11-21 19:26:28</sys_created_on>
 <sys_id>1980bcb147935110328ca368436d435a</sys_id>
-<sys_mod_count>154</sys_mod_count>
+<sys_mod_count>147</sys_mod_count>
 <sys_name>CheckmarxOneUtilBase</sys_name>
 <sys_package display_value="Checkmarx One Vulnerability Integration" source="x_chec3_chexone">3d20e92d47471110328ca368436d436a</sys_package>
 <sys_policy/>
 <sys_scope display_value="Checkmarx One Vulnerability Integration">3d20e92d47471110328ca368436d436a</sys_scope>
 <sys_update_name>sys_script_include_1980bcb147935110328ca368436d435a</sys_update_name>
 <sys_updated_by>admin</sys_updated_by>
-<sys_updated_on>2023-06-19 13:11:08</sys_updated_on>
+<sys_updated_on>2023-06-22 07:21:21</sys_updated_on>
 </sys_script_include>
 </unload>


### PR DESCRIPTION
Added API call to get one project while Saving Credentials in the Configuration Page.
Reuse of Access Token which is already in the database and is not expired.
Testing:

In the 'Checkmarx One Configuration' page add all credentials and do "Save and Test Credentials". It should validate credentials. checked logs in "Outbound HTTP Request". It is calling API to fetch only 1 project.
Added Client Id and ran the integration, It succeed the integrations.
Rerun the integration, it succeeds the integration. And access token is the same as in 2nd test.
Wait for the access token to expire, and run the integration, this time new access token got generated.
Added Different Client IDs and run the integration, a new access token got generated and integration succeed.