### PR TITLE
[CxOne] Add Scan Origin, Source and Scan Type in the Synchronization

### DIFF
--- a/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
+++ b/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
@@ -69,11 +69,15 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                 //sca scan summary
                 if (includesca && jsonLastScanSummResp.scans[item].engines.toString().includes("sca")) {
                     var scaresponsevul = this.UTIL.getScanSummaryInfo(this.IMPLEMENTATION, jsonLastScanSummResp.scans[item].id);
+                    var scaScanType = "Full Scan" ;
                     if (scaresponsevul != -1) {
                         scaScanSummaryAll += '<scan id="' + 'sca' + jsonLastScanSummResp.scans[item].id + '" app_id="' + appId +
                             '" last_scan_date="' + this.UTIL.parseDate(jsonLastScanSummResp.scans[item].updatedAt) +
                             '" total_no_flaws="' + scaresponsevul +
                             '" branch="' + jsonLastScanSummResp.scans[item].branch +
+                            '" scan_origin="' + jsonLastScanSummResp.scans[item].sourceOrigin +
+                            '" scan_source="' + jsonLastScanSummResp.scans[item].sourceType +
+                            '" scan_type="' +  scaScanType +
                             '" app_name="' + appId + '"/>';
                     }
                 }
@@ -81,6 +85,7 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                 //sast scan summary
                 if (includesast && jsonLastScanSummResp.scans[item].engines.toString().includes("sast")) {
                     var sastresponsevul = this.UTIL.getSastScanSummaryInfo(this.IMPLEMENTATION, jsonLastScanSummResp.scans[item].id);
+                     var sastScanType = jsonLastScanSummResp.scans[item].metadata.configs[0].value.incremental == "false" ? "Full Scan" :"Incremental Scan";
                     if (sastresponsevul != -1) {
                         var loc = this._getLOCforSAST(jsonLastScanSummResp.scans[item].statusDetails);
                         sastScanSummaryAll += '<scan id="' + 'sast' + jsonLastScanSummResp.scans[item].id + '" app_id="' + appId +
@@ -88,6 +93,9 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                             '" total_no_flaws="' + sastresponsevul +
                             '" loc="' + loc +
                             '" branch="' + jsonLastScanSummResp.scans[item].branch +
+                            '" scan_origin="' + jsonLastScanSummResp.scans[item].sourceOrigin +
+                            '" scan_source="' + jsonLastScanSummResp.scans[item].sourceType +
+                            '" scan_type="' +  sastScanType +
                             '" app_name="' + appId + '"/>';
                     }
                 }
@@ -95,11 +103,15 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                 //kics scan summary
                 if (includekics && jsonLastScanSummResp.scans[item].engines.toString().includes("kics")) {
                     var kicsresponsevul = this.UTIL.getKicsScanSummaryInfo(this.IMPLEMENTATION, jsonLastScanSummResp.scans[item].id);
+                    var scanType = "Full Scan";
                     if (kicsresponsevul != -1) {
                         kicsScanSummaryAll += '<scan id="' + 'IaC' + jsonLastScanSummResp.scans[item].id + '" app_id="' + appId +
                             '" last_scan_date="' + this.UTIL.parseDate(jsonLastScanSummResp.scans[item].updatedAt) +
                             '" total_no_flaws="' + kicsresponsevul +
                             '" branch="' + jsonLastScanSummResp.scans[item].branch +
+                            '" scan_origin="' + jsonLastScanSummResp.scans[item].sourceOrigin +
+                            '" scan_source="' + jsonLastScanSummResp.scans[item].sourceType +
+                            '" scan_type="' +  scanType +
                             '" app_name="' + appId + '"/>';
                     }
                 }

--- a/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
+++ b/Scripts/CheckmarxOneScanSummaryIntegration_sys_script_include_d7f2d2e447131110328ca368436d4321.xml
@@ -69,7 +69,6 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                 //sca scan summary
                 if (includesca && jsonLastScanSummResp.scans[item].engines.toString().includes("sca")) {
                     var scaresponsevul = this.UTIL.getScanSummaryInfo(this.IMPLEMENTATION, jsonLastScanSummResp.scans[item].id);
-                    var scaScanType = "Full Scan" ;
                     if (scaresponsevul != -1) {
                         scaScanSummaryAll += '<scan id="' + 'sca' + jsonLastScanSummResp.scans[item].id + '" app_id="' + appId +
                             '" last_scan_date="' + this.UTIL.parseDate(jsonLastScanSummResp.scans[item].updatedAt) +
@@ -77,7 +76,7 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                             '" branch="' + jsonLastScanSummResp.scans[item].branch +
                             '" scan_origin="' + jsonLastScanSummResp.scans[item].sourceOrigin +
                             '" scan_source="' + jsonLastScanSummResp.scans[item].sourceType +
-                            '" scan_type="' +  scaScanType +
+                            '" scan_type="' +  'Full Scan' +
                             '" app_name="' + appId + '"/>';
                     }
                 }
@@ -103,7 +102,6 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                 //kics scan summary
                 if (includekics && jsonLastScanSummResp.scans[item].engines.toString().includes("kics")) {
                     var kicsresponsevul = this.UTIL.getKicsScanSummaryInfo(this.IMPLEMENTATION, jsonLastScanSummResp.scans[item].id);
-                    var scanType = "Full Scan";
                     if (kicsresponsevul != -1) {
                         kicsScanSummaryAll += '<scan id="' + 'IaC' + jsonLastScanSummResp.scans[item].id + '" app_id="' + appId +
                             '" last_scan_date="' + this.UTIL.parseDate(jsonLastScanSummResp.scans[item].updatedAt) +
@@ -111,7 +109,7 @@ CheckmarxOneScanSummaryIntegration.prototype = Object.extendsObject(sn_vul.Appli
                             '" branch="' + jsonLastScanSummResp.scans[item].branch +
                             '" scan_origin="' + jsonLastScanSummResp.scans[item].sourceOrigin +
                             '" scan_source="' + jsonLastScanSummResp.scans[item].sourceType +
-                            '" scan_type="' +  scanType +
+                            '" scan_type="' +  'Full Scan' +
                             '" app_name="' + appId + '"/>';
                     }
                 }

--- a/Scripts/CheckmarxOneScanSummaryProcessor_sys_script_include_ec0e828f47f42110328ca368436d433b.xml
+++ b/Scripts/CheckmarxOneScanSummaryProcessor_sys_script_include_ec0e828f47f42110328ca368436d433b.xml
@@ -47,6 +47,7 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
                         sastdata['scan_summary_name'] = Sastattributes.id + ' ' + sastdata['last_scan_date'];
 						sastdata['scan_analysis_size'] = +Sastattributes.loc;
 						sastdata['tags'] = Sastattributes.branch;
+                        sastdata['scan_submitted_by'] = 'Scan Origin: ' + Sastattributes.scan_origin + '\n' + 'Scan Source: ' + Sastattributes.scan_source + '\n' + 'Scan Type: ' + Sastattributes.scan_type + '\n';
                         this._upsert(sastdata);
                     } catch (ex) {
                         errorMessage = gs.getMessage("Error in retriving data for scan list integration!");
@@ -76,6 +77,7 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
                         data['last_scan_date'] = new GlideDateTime(attributes.last_scan_date);
                         data['scan_summary_name'] = attributes.id + ' ' + data['last_scan_date'];
 						data['tags'] = attributes.branch;
+                        data['scan_submitted_by'] = 'Scan Origin: ' + attributes.scan_origin + '\n' + 'Scan Source: ' + attributes.scan_source + '\n' + 'Scan Type: ' + attributes.scan_type + '\n';
                         this._upsert(data);
                     } catch (ex) {
                         errorMessage = gs.getMessage("Error in retriving data for scan list integration!");
@@ -105,6 +107,7 @@ CheckmarxOneScanSummaryProcessor.prototype = Object.extendsObject(sn_vul.Applica
                         kicsdata['last_scan_date'] = new GlideDateTime(kicsattributes.last_scan_date);
                         kicsdata['scan_summary_name'] = kicsattributes.id + ' ' + kicsdata['last_scan_date'];
 						kicsdata['tags'] = kicsattributes.branch;
+                        kicsdata['scan_submitted_by'] = 'Scan Origin: ' + kicsattributes.scan_origin + '\n' + 'Scan Source: ' + kicsattributes.scan_source + '\n' + 'Scan Type: ' + kicsattributes.scan_type + '\n';
                         this._upsert(kicsdata);
                     } catch (ex) {
                         errorMessage = gs.getMessage("Error in retriving data for scan list integration!");


### PR DESCRIPTION
**Changes**
In 2nd integration added **Scan Origin , Scan Source, Scan Type** in xml as well as in processing script .
**Table Name - sn_vul_app_vul_scan_summary
Column Name - scan_submitted_by**

**Test Case** 
1. Run 2nd integration _.> open xml -> in XML all the details(Scan Origin , Scan Source, Scan Type) related to SAST,SCA and kiks.
2. Check this above details in below table-> column
**Table Name - sn_vul_app_vul_scan_summary
Column Name - scan_submitted_by**